### PR TITLE
New "fnum" function for use with cmp_deeply to compare results at higher

### DIFF
--- a/test/includes.pm
+++ b/test/includes.pm
@@ -4,13 +4,14 @@ use strict;
 use File::Spec;
 use Cwd;
 use Test::More;
+use Test::Deep;
 use File::Path 'rmtree';
 use File::Copy 'cp';
 use Config;
 
 require Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT = qw(get_major_minor_nm_version get_command get_command_without_args get_psn_options cmp_float cmp_float_matrix cmp_float_array create_test_dir remove_test_dir copy_test_files like_file_row unlike_file_row do_course_tests cmp_relative redirect_stderr);
+our @EXPORT = qw(get_major_minor_nm_version fnum get_command get_command_without_args get_psn_options cmp_float cmp_float_matrix cmp_float_array create_test_dir remove_test_dir copy_test_files like_file_row unlike_file_row do_course_tests cmp_relative redirect_stderr);
 
 # Setup an include path to the lib directory
 # First get the path of this module and split out the directory part
@@ -135,6 +136,33 @@ sub get_command
     return $command_line;
 }
 
+# Automatically generate a tolerance for a floating point number. Based on the
+# principle that the string representation of a floating point number is only
+# as precise as the literal source code representation it was derived from.  If
+# a second argument is supplied, it is a floating point number to derive the
+# tolerance from if that tolerance is more lenient that of the first
+# argument.
+sub fnum {
+	my $num = shift;
+	my $tolerance;
+	my $tolnum;
+	my $index = index($num, ".");
+	my $length = length($num) - $index - 1;
+	if ($index >= 0) {
+		$tolerance = ( "0." .  "0" x $length . 5) + 0;
+	} else {
+		$tolerance = 0;
+	}
+	if (@_) {
+		$tolnum = shift;
+		$index = index($tolnum, ".");
+		my $tollength = length($tolnum) - $index - 1;
+		if ($tollength < $length) {
+			$tolerance = ( "0." .  "0" x $tollength . 5) + 0;
+		}
+	}
+	num($num, $tolerance);
+}
 
 sub cmp_float
 {
@@ -198,7 +226,7 @@ sub cmp_float_matrix
         }
     }
 
-    is_deeply($new_A, $new_B, $text);
+    cmp_deeply($new_A, $new_B, $text);
 }
 
 

--- a/test/unit/array.t
+++ b/test/unit/array.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Deep;
 use Test::Exception;
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm

--- a/test/unit/binning.t
+++ b/test/unit/binning.t
@@ -6,6 +6,7 @@
 use strict;
 use warnings;
 use Test::More tests => 50;
+use Test::Deep;
 use Test::Exception;
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
@@ -66,7 +67,7 @@ my @negB_result = qw(-9944.2643508978 -6633.93930200631 -6331.86101749057 -3901.
 my $negB = binning::calcNegB(\@N, \@meanIdv, $totMeanIdv);
 
 foreach my $i (0..@$negB - 1) {
-	is ($$negB[$i], $negB_result[$i], "negB $i");
+	cmp_deeply ($$negB[$i], fnum($negB_result[$i]), "negB $i");
 }
 
 done_testing();

--- a/test/unit/covmat.t
+++ b/test/unit/covmat.t
@@ -4,6 +4,7 @@
 use strict;
 use warnings;
 use Test::More tests=>5;
+use Test::Deep;
 use Test::Exception;
 use File::Path 'rmtree';
 use FindBin qw($Bin);
@@ -38,7 +39,7 @@ my $ref = get_cov();
 #foreach my $line (@{$ref}){
 #	print join(' ',@{$line})."\n";
 #}
-cmp_ok($ref->[0]->[0],'==',1.46167231816964,"cov 1,1");
+cmp_deeply($ref->[0]->[0], fnum(1.46167231816964),"cov 1,1");
 cmp_ok($ref->[0]->[1],'==',$ref->[1]->[0],"cov 1,2 2,1");
 cmp_ok($ref->[2]->[3],'==',$ref->[3]->[2],"cov 3,4 4,3");
 cmp_ok($ref->[3]->[4],'==',1.43639675,"cov 4,5");

--- a/test/unit/linear_algebra.t
+++ b/test/unit/linear_algebra.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Deep;
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages
@@ -14,10 +15,10 @@ my @A = ([1, 2, 3], [2.1, 4, 5], [3.25, 5.17, 19]);
 
 my @B = ([1, 2.1, 3.25], [2, 4, 5.17], [3, 5, 19]);
 my $C = linear_algebra::subtract(\@A, \@B);
-is_deeply($C, [[ 0.  , -0.1 , -0.25], [ 0.1 ,  0.  , -0.17], [ 0.25,  0.17,  0.  ]], "matrix subtraction");
+cmp_deeply($C, [[ 0.  , fnum(-0.1) , -0.25], [ fnum(0.1) ,  0.  , -0.17], [ 0.25,  0.17,  0.  ]], "matrix subtraction");
 is (linear_algebra::max($C), 0.25, "matrix maximum");
 linear_algebra::absolute($C);
-is_deeply($C, [[ 0.  , 0.1 , 0.25], [ 0.1,  0., 0.17], [ 0.25,  0.17,  0. ]], "matrix absolute");
+cmp_deeply($C, [[ 0.  , fnum(0.1) , 0.25], [ fnum(0.1),  0., 0.17], [ 0.25,  0.17,  0. ]], "matrix absolute");
 
 # read_from_file
 my $testdir = create_test_dir("linear_algebra_unit");

--- a/test/unit/math.t
+++ b/test/unit/math.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Deep;
 use Test::Exception;
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
@@ -33,7 +34,7 @@ is (round(-18.999), -19, "round negative down");
 is (round(-199), -199, "round negative integer");
 
 # eps
-is (eps(1), 2.220446049250313e-16, "eps(1)");
+cmp_deeply (eps(1), fnum(2.220446049250313e-16), "eps(1)");
 is (eps(-1), 2.220446049250313e-16, "eps(-1)");
 is (eps(0.00073), 1.084202172485504e-19, "eps(0.00073)");
 is (eps(400000000000000), 0.0625, "eps(400000000000000)");

--- a/test/unit/multnorm.t
+++ b/test/unit/multnorm.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Deep;
 #use Test::More;
 use Test::Exception;
 use FindBin qw($Bin);
@@ -175,16 +176,16 @@ my $inflated=tool::sir::inflate_covmatrix(matrix => $covar,
 										  inflation => [2,2,2,2,2,2,2,2]);
 
 
-cmp_ok($covar->[0]->[0],'==',6.10693E+00,'covar element 1,1 after inflation not changed');
-cmp_ok($covar->[1]->[5],'==',1.18743E-02,'covar element 2,6 after inflation not changed');
-cmp_ok($covar->[2]->[2],'==',3.75907E-04,'covar element 3,3 after inflation not changed');
-cmp_ok($covar->[3]->[1],'==',-4.02777E-02,'covar element 4,2 after inflation not changed');
-cmp_ok($covar->[4]->[7],'==',6.19395E-05,'covar element 5,8 after inflation not changed');
-cmp_ok($covar->[7]->[0],'==',1.53110E-02,'covar element 8,1 after inflation not changed');
-cmp_ok($covar->[6]->[5],'==',7.25938E-03,'covar element 7,6 after inflation not changed');
-cmp_ok($covar->[7]->[7],'==',1.69362E-03,'covar element 8,8 after inflation not changed');
-cmp_ok($covar->[6]->[3],'==',2.75131E-03,'covar element 7,4 after inflation not changed');
-cmp_ok($covar->[4]->[6],'==',-3.05686E-04,'covar element 5,7 after inflation not changed');
+cmp_deeply($covar->[0]->[0], fnum(6.10693E+00),'covar element 1,1 after inflation not changed');
+cmp_deeply($covar->[1]->[5], fnum(1.18743E-02),'covar element 2,6 after inflation not changed');
+cmp_deeply($covar->[2]->[2], fnum(3.75907E-04),'covar element 3,3 after inflation not changed');
+cmp_deeply($covar->[3]->[1], fnum(-4.02777E-02),'covar element 4,2 after inflation not changed');
+cmp_deeply($covar->[4]->[7], fnum(6.19395E-05),'covar element 5,8 after inflation not changed');
+cmp_deeply($covar->[7]->[0], fnum(1.53110E-02),'covar element 8,1 after inflation not changed');
+cmp_deeply($covar->[6]->[5], fnum(7.25938E-03),'covar element 7,6 after inflation not changed');
+cmp_deeply($covar->[7]->[7], fnum(1.69362E-03),'covar element 8,8 after inflation not changed');
+cmp_deeply($covar->[6]->[3], fnum(2.75131E-03),'covar element 7,4 after inflation not changed');
+cmp_deeply($covar->[4]->[6], fnum(-3.05686E-04),'covar element 5,7 after inflation not changed');
 
 
 

--- a/test/unit/relmultnorm.t
+++ b/test/unit/relmultnorm.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Deep;
 #use Test::More;
 use Test::Exception;
 use FindBin qw($Bin);
@@ -20,21 +21,21 @@ my @perc = (0,0.025,0.05,0.1,0.3,0.5,0.7,0.9,0.95,0.975,1);
 my @qua=@{tool::sir::quantile(numbers => \@numbers,probs => \@perc)};
 my @facit = (1,5.5,10.5,20.5,60.5,100.5,140.5,180.5,190.5,195.5,200);
 for (my $i=0; $i< scalar(@perc); $i++){
-	cmp_ok($qua[$i],'==',$facit[$i],"quantile index $i vec 200");
+	cmp_deeply($qua[$i], fnum($facit[$i]),"quantile index $i vec 200");
 }
 
 @numbers = (1..100);
 @qua=@{tool::sir::quantile(numbers => \@numbers,probs => \@perc)};
 @facit = (1,3,5.5,10.5,30.5,50.5,70.5,90.5,95.5,98,100);
 for (my $i=0; $i< scalar(@perc); $i++){
-	cmp_ok($qua[$i],'==',$facit[$i],"quantile index $i vec 100");
+	cmp_deeply($qua[$i], fnum($facit[$i]),"quantile index $i vec 100");
 }
 
 @numbers = (1..10);
 @qua=@{tool::sir::quantile(numbers => \@numbers,probs => \@perc)};
 @facit=(1,1,1,1.5,3.5,5.5,7.5,9.5,10,10,10);
 for (my $i=0; $i< scalar(@perc); $i++){
-	cmp_ok($qua[$i],'==',$facit[$i],"quantile index $i vec 10");
+	cmp_deeply($qua[$i],fnum($facit[$i]),"quantile index $i vec 10");
 }
 
 
@@ -51,13 +52,13 @@ my $output = output->new(filename => $dir . $file);
 
 my $icm = tool::sir::get_nonmem_inverse_covmatrix(output => $output);
 
-cmp_ok($icm->element(1,1),'==',8.46492E+06,'inverse element 1,1');
-cmp_ok($icm->element(3,1),'==',9.12148E+03,'inverse element 3,1');
-cmp_ok($icm->element(1,3),'==',9.12148E+03,'inverse element 1,3');
-cmp_ok($icm->element(1,5),'==',-2.86424E+04,'inverse element 1,5');
-cmp_ok($icm->element(4,2),'==',-1.55874E+02,'inverse element 4,2');
-cmp_ok($icm->element(5,3),'==',-1.03606E+02,'inverse element 5,3');
-cmp_ok($icm->element(5,5),'==',5.96396E+03,'inverse element 5,5');
+cmp_deeply($icm->element(1,1), fnum(8.46492E+06),'inverse element 1,1');
+cmp_deeply($icm->element(3,1), fnum(9.12148E+03),'inverse element 3,1');
+cmp_deeply($icm->element(1,3), fnum(9.12148E+03),'inverse element 1,3');
+cmp_deeply($icm->element(1,5), fnum(-2.86424E+04),'inverse element 1,5');
+cmp_deeply($icm->element(4,2), fnum(-1.55874E+02),'inverse element 4,2');
+cmp_deeply($icm->element(5,3), fnum(-1.03606E+02),'inverse element 5,3');
+cmp_deeply($icm->element(5,5), fnum(5.96396E+03),'inverse element 5,5');
 
 my $hash = output::get_nonmem_parameters(output => $output);
 
@@ -70,11 +71,11 @@ is(scalar(@{$arr}),0,'setup block posdef count 3');
 
 my $thetas = $hash->{'values'};
 
-cmp_ok($hash->{'values'}->[0],'==',5.55363E-03,' theta 1');
-cmp_ok($hash->{'values'}->[1],'==',1.33638E+00,' theta 2');
-cmp_ok($hash->{'values'}->[2],'==',4.97064E-01,' theta 3');
-cmp_ok($hash->{'values'}->[3],'==',3.76272E-01,' theta 4');
-cmp_ok($hash->{'values'}->[4],'==',1.28122E-01,' theta 5');
+cmp_deeply($hash->{'values'}->[0], fnum(5.55363E-03),' theta 1');
+cmp_deeply($hash->{'values'}->[1], fnum(1.33638E+00),' theta 2');
+cmp_deeply($hash->{'values'}->[2], fnum(4.97064E-01),' theta 3');
+cmp_deeply($hash->{'values'}->[3], fnum(3.76272E-01),' theta 4');
+cmp_deeply($hash->{'values'}->[4], fnum(1.28122E-01),' theta 5');
 cmp_ok($hash->{'lower_bounds'}->[0],'==',0,' lower bound theta 1');
 cmp_ok($hash->{'lower_bounds'}->[1],'==',0,' lower bound theta 2');
 cmp_ok($hash->{'lower_bounds'}->[2],'==',0,' lower bound theta 3');
@@ -100,22 +101,22 @@ my $mu = $mat->new_from_rows( [$thetas] );
 #print $mu;
 
 
-cmp_ok($mu->element(1,1),'==',5.55363E-03,'mu 1,1');
-cmp_ok($mu->element(1,2),'==',1.33638E+00,'mu 1,2');
-cmp_ok($mu->element(1,3),'==',4.97064E-01,'mu 1,3');
-cmp_ok($mu->element(1,4),'==',3.76272E-01,'mu 1,4');
-cmp_ok($mu->element(1,5),'==',1.28122E-01,'mu 1,5');
+cmp_deeply($mu->element(1,1), fnum(5.55363E-03),'mu 1,1');
+cmp_deeply($mu->element(1,2), fnum(1.33638E+00),'mu 1,2');
+cmp_deeply($mu->element(1,3), fnum(4.97064E-01),'mu 1,3');
+cmp_deeply($mu->element(1,4), fnum(3.76272E-01),'mu 1,4');
+cmp_deeply($mu->element(1,5), fnum(1.28122E-01),'mu 1,5');
 
 my $nsamples=3;
 
 my $covar = tool::sir::get_nonmem_covmatrix(output => $output);
 
-cmp_ok($covar->[0]->[0],'==',1.55838E-07,'covar element 1,1');
-cmp_ok($covar->[1]->[1],'==',6.38430E-03,'covar element 2,2');
-cmp_ok($covar->[1]->[2],'==',-1.94326E-03,'covar element 2,3');
-cmp_ok($covar->[2]->[1],'==',-1.94326E-03,'covar element 3,2');
-cmp_ok($covar->[3]->[2],'==',-1.32639E-03,'covar element 4,3');
-cmp_ok($covar->[4]->[4],'==',eval(1.75502E-04),'covar element 5,5');
+cmp_deeply($covar->[0]->[0], fnum(1.55838E-07),'covar element 1,1');
+cmp_deeply($covar->[1]->[1], fnum(6.38430E-03),'covar element 2,2');
+cmp_deeply($covar->[1]->[2], fnum(-1.94326E-03),'covar element 2,3');
+cmp_deeply($covar->[2]->[1], fnum(-1.94326E-03),'covar element 3,2');
+cmp_deeply($covar->[3]->[2], fnum(-1.32639E-03),'covar element 4,3');
+cmp_deeply($covar->[4]->[4], fnum(1.75502E-04),'covar element 5,5');
 
 random_set_seed_from_phrase("hej pa dig");
 my ($gotsamples,$dirt) = tool::sir::sample_multivariate_normal(samples=>$nsamples,
@@ -143,11 +144,11 @@ my $sampled_params_arr = tool::sir::create_sampled_params_arr(samples_array => $
 															  labels_hash => $hash,
 															  user_labels => 1);
 
-cmp_float($sampled_params_arr->[0]->{'theta'}->{'CL'}, 0.00579867653819879, 'sampled CL');
-cmp_float($sampled_params_arr->[0]->{'theta'}->{'V'}, 1.20800900217457, 'sampled V');
-cmp_float($sampled_params_arr->[0]->{'theta'}->{'THETA3'}, 0.568698687977855, 'sampled THETA3');
-cmp_float($sampled_params_arr->[0]->{'theta'}->{'THETA4'}, 0.369700885223909, 'sampled THETA4');
-cmp_float($sampled_params_arr->[0]->{'theta'}->{'THETA5'}, 0.118821314516974, 'sampled THETA5');
+cmp_deeply($sampled_params_arr->[0]->{'theta'}->{'CL'}, fnum(0.00579867653819879), 'sampled CL');
+cmp_deeply($sampled_params_arr->[0]->{'theta'}->{'V'}, fnum(1.20800900217457), 'sampled V');
+cmp_deeply($sampled_params_arr->[0]->{'theta'}->{'THETA3'}, fnum(0.568698687977855), 'sampled THETA3');
+cmp_deeply($sampled_params_arr->[0]->{'theta'}->{'THETA4'}, fnum(0.369700885223909), 'sampled THETA4');
+cmp_deeply($sampled_params_arr->[0]->{'theta'}->{'THETA5'}, fnum(0.118821314516974), 'sampled THETA5');
 
 my $statshash = tool::sir::empirical_statistics(sampled_params_arr => $sampled_params_arr,
 												labels_hash=> $hash,
@@ -318,10 +319,10 @@ cmp_ok($icm->element(1,5),'==',-3.17183E+00,'inverse element 1,5');
 cmp_ok($icm->element(4,2),'==',1.38220E+01,'inverse element 4,2');
 cmp_ok($icm->element(5,3),'==',-2.66596E+02,'inverse element 5,3');
 cmp_ok($icm->element(5,5),'==',1.48718E+04,'inverse element 5,5');
-cmp_ok($icm->element(6,2),'==',-7.76844E-01,'inverse element 6,2');
+cmp_deeply($icm->element(6,2),fnum(-7.76844E-01),'inverse element 6,2');
 cmp_ok($icm->element(5,6),'==',-3.88572E+02,'inverse element 5,6');
 cmp_ok($icm->element(6,6),'==',3.04099E+02,'inverse element 6,6');
-cmp_ok($icm->element(1,7),'==',-4.35392E-02,'inverse element 1,7');
+cmp_deeply($icm->element(1,7), fnum(-4.35392E-02),'inverse element 1,7');
 cmp_ok($icm->element(7,3),'==',-6.35795E+01,'inverse element 7,3');
 cmp_ok($icm->element(7,7),'==',2.50300E+01,'inverse element 7,7');
 cmp_ok($icm->element(8,3),'==',3.32151E+02,'inverse element 8,3');
@@ -367,7 +368,7 @@ $mu = $mat->new_from_rows( [$params] );
 
 #print $mu;
 
-cmp_ok($mu->element(1,1),'==',3.28661E+01,'mu 1,1');
+cmp_deeply($mu->element(1,1), fnum(3.28661E+01),'mu 1,1');
 cmp_ok($mu->element(1,8),'==',2.07708E-01,'mu 1,8');
 
 #my $nsamples=3;
@@ -394,10 +395,10 @@ cmp_ok($covar->[1]->[5],'==',1.18743E-02,'covar element 2,6');
 cmp_ok($covar->[2]->[2],'==',3.75907E-04,'covar element 3,3');
 cmp_ok($covar->[3]->[1],'==',-4.02777E-02,'covar element 4,2');
 cmp_ok($covar->[4]->[7],'==',6.19395E-05,'covar element 5,8');
-cmp_ok($covar->[7]->[0],'==',1.53110E-02,'covar element 8,1');
+cmp_deeply($covar->[7]->[0],fnum(1.53110E-02),'covar element 8,1');
 cmp_ok($covar->[6]->[5],'==',7.25938E-03,'covar element 7,6');
-cmp_ok($covar->[7]->[7],'==',1.69362E-03,'covar element 8,8');
-cmp_ok($covar->[6]->[3],'==',2.75131E-03,'covar element 7,4');
+cmp_deeply($covar->[7]->[7],fnum(1.69362E-03),'covar element 8,8');
+cmp_deeply($covar->[6]->[3],fnum(2.75131E-03),'covar element 7,4');
 cmp_ok($covar->[4]->[6],'==',-3.05686E-04,'covar element 5,7');
 
 $inflated = tool::sir::inflate_covmatrix(matrix => $covar,
@@ -408,9 +409,9 @@ cmp_float($inflated->[1]->[5],eval(2*1.18743E-02),'inflated covar element 2,6');
 cmp_float($inflated->[2]->[2],eval(2*3.75907E-04),'inflated covar element 3,3');
 cmp_float($inflated->[3]->[1],eval(2*-4.02777E-02),'inflated covar element 4,2');
 cmp_float($inflated->[4]->[7],eval(2*6.19395E-05),'inflated covar element 5,8');
-cmp_float($inflated->[7]->[0],eval(2*1.53110E-02),'inflated covar element 8,1');
+cmp_deeply($inflated->[7]->[0],fnum(2*1.53110E-02),'inflated covar element 8,1');
 cmp_float($inflated->[6]->[5],eval(2*7.25938E-03),'inflated covar element 7,6');
-cmp_float($inflated->[7]->[7],eval(2*1.69362E-03),'inflated covar element 8,8');
+cmp_deeply($inflated->[7]->[7],fnum(2*1.69362E-03),'inflated covar element 8,8');
 cmp_float($inflated->[6]->[3],eval(2*2.75131E-03),'inflated covar element 7,4');
 cmp_float($inflated->[4]->[6],eval(2*-3.05686E-04),'inflated covar element 5,7');
 
@@ -642,7 +643,11 @@ foreach my $fast_posdef (0,1) {
                                                          cholesky_decomposition => $fast_posdef);
     is($accept,1,'check blocks posdef accept 9'.$str);
     is($adjusted,1,'check blocks posdef adjusted 9'.$str);
-    is_deeply($xvec,[1,1,1,3,9.99999999833334e-09,3.0000000005,2.9999999995,3.0000000005,1,0.1,1],'post xvec 9'.$str);
+    cmp_deeply($xvec,[1,1,1,3
+        ,fnum(9.99999999833334e-09)
+        ,fnum(3.0000000005)
+        ,fnum(2.9999999995)
+        ,fnum(3.0000000005),1,fnum(0.1),1],'post xvec 9'.$str);
 }
 
 

--- a/test/unit/so/parsers/nmoutput.t
+++ b/test/unit/so/parsers/nmoutput.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Deep;
 use FindBin qw($Bin);
 use lib "$Bin/../../.."; #location of includes.pm
 use includes; #file with paths to PsN packages
@@ -253,7 +254,13 @@ SKIP: {
     is_deeply($so->SOBlock->[0]->Estimation->PrecisionPopulationEstimates->MLE->RelativeStandardError->columnId, [ 'Parameter', 'RSE' ], "Pheno: RelativeStandardError names");
     is_deeply($so->SOBlock->[0]->Estimation->PrecisionPopulationEstimates->MLE->RelativeStandardError->columnType, [ ('undefined') x 2 ], "Pheno: RelativeStandardError column types");
     is_deeply($so->SOBlock->[0]->Estimation->PrecisionPopulationEstimates->MLE->RelativeStandardError->valueType, [ 'string', 'real' ], "Pheno: RelativeStandardError value types");
-    is_deeply($so->SOBlock->[0]->Estimation->PrecisionPopulationEstimates->MLE->RelativeStandardError->columns, [ [ 'CL', 'V', 'IVCL', 'IVV', 'SIGMA_1_1_' ], [ 7.11711711711712, 5.96268656716418, 63.1578947368421, 24.5774647887324, 20.6707317073171 ]  ], "Pheno: RelativeStandardError columns");
+    cmp_deeply($so->SOBlock->[0]->Estimation->PrecisionPopulationEstimates->MLE->RelativeStandardError->columns, [ [ 'CL', 'V', 'IVCL', 'IVV', 'SIGMA_1_1_' ], [
+      fnum(7.11711711711712),
+    , fnum(5.96268656716418)
+    , fnum(63.1578947368421)
+    , fnum(24.5774647887324)
+    , fnum(20.6707317073171)
+] ], "Pheno: RelativeStandardError columns");
 
     is($so->SOBlock->[0]->Estimation->OFMeasures->Deviance, 742.051, "Pheno: Deviance");
     is_deeply($so->SOBlock->[0]->Estimation->OFMeasures->IndividualContribToLL->columnId, [ 'ID', 'ICtoLL' ], "Pheno: ICTOLL columnIds");

--- a/test/unit/tool/bootstrap.t
+++ b/test/unit/tool/bootstrap.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Deep;
 use Test::Exception;
 use File::Copy qw(cp);
 use FindBin qw($Bin);
@@ -617,28 +618,28 @@ cp("$test_files/bootstrap/some_covstep_fail/raw_results_structure", $tempdir);
 
 $bootstrap->prepare_results();
 
-cmp_float_array($bootstrap->result_parameters->{'means'}[0][0],
+cmp_deeply($bootstrap->result_parameters->{'means'}[0][0],
 [
-'-596.9881162915',
-'32.7712909091',
-'22.2971909091',
-'0.2944600909',
-'0.0741762727',
-'0.3300864545',
-'0.3848421818',
-'1.0535450909',
-'0.1362522618',
-'0.2472101818',
-'1',
-'2.4218914286',
-'3.7750871429',
-'0.0203821429',
-'0.0388025857',
-'0.00845522857',
-'0.0679633286',
-'0.2562745714',
-'0.0875501571',
-'0.0503794429'
+fnum(-596.9881162915),
+fnum(32.7712909091),
+fnum(22.2971909091),
+fnum(0.2944600909),
+fnum(0.0741762727),
+fnum(0.3300864545),
+fnum(0.3848421818),
+fnum(1.0535450909),
+fnum(0.1362522618),
+fnum(0.2472101818),
+fnum(1),
+fnum(2.4218914286),
+fnum(3.7750871429),
+fnum(0.0203821429),
+fnum(0.0388025857),
+fnum(0.00845522857),
+fnum(0.0679633286),
+fnum(0.2562745714),
+fnum(0.0875501571),
+fnum(0.0503794429)
 ], "bootstrap means summarize some covstep fail ");
 
 cmp_float_array($bootstrap->result_parameters->{'medians'}[0][0],

--- a/test/unit/tool/frem.t
+++ b/test/unit/tool/frem.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Deep;
 use Test::Exception;
 use FindBin qw($Bin);
 use lib "$Bin/../.."; #location of includes.pm
@@ -319,12 +320,11 @@ my $imp_model = model->new(filename => "$modeldir/frem/mox_imp_4.mod",
                                                                end_eta_2 => 5,
                                                                model => $imp_model);
 
-$ans=[[0.1989847636,0.5241788523,0.5297193498],
-      [0.5241788523,1.3696569641,0.2012698903],
-      [0.5297193498,0.2012698903,0.8842831035 ]];
+$ans=[[fnum(0.1989847636),fnum(0.5241788523),fnum(0.5297193498)],
+      [fnum(0.5241788523),fnum(1.3696569641),fnum(0.2012698903)],
+      [fnum(0.5297193498),fnum(0.2012698903),fnum(0.8842831035)]];
 
-
-cmp_float_matrix($corr,$ans,'get_correlation_matrix_from_phi 3, importance sampling two est');
+cmp_deeply($corr,$ans,'get_correlation_matrix_from_phi 3, importance sampling two est');
 is (length($message),0,'no error get_correlation_matrix 3');
 
 

--- a/test/unit/tool/lasso.t
+++ b/test/unit/tool/lasso.t
@@ -4,6 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Deep;
 use Test::Exception;
 use File::Path 'rmtree';
 use FindBin qw($Bin);
@@ -380,11 +381,14 @@ cmp_float($refm->problems->[0]->thetas->[6]->options->[0]->init,$init,'setup_opt
 
 $sd =sprintf("%.5f",$statistics->{'ACE'}{1}{'sd'}{0});
 $init = exp(1-($abssum/0.1))*$finalhash{'theta'}->{'TH8 VACE0'}/($sd);
-is($refm->problems->[0]->thetas->[7]->options->[0]->init,$init,'setup_optimal_model init 8'); #VACE0
+cmp_deeply($refm->problems->[0]->thetas->[7]->options->[0]->init,
+	fnum($init, $refm->problems->[0]->thetas->[7]->options->[0]->init),
+	'setup_optimal_model init 8'); #VACE0
 
 $sd =sprintf("%.5f",$statistics->{'AGE'}{2}{'sd'});
 $init = exp(1-($abssum/0.1))*$finalhash{'theta'}->{'TH9 VAGE'}/($sd);
-is($refm->problems->[0]->thetas->[8]->options->[0]->init,$init,'setup_optimal_model init 9'); #VAGE
+cmp_deeply($refm->problems->[0]->thetas->[8]->options->[0]->init,
+	fnum($init, $refm->problems->[0]->thetas->[8]->options->[0]->init),'setup_optimal_model init 9'); #VAGE
 
 my $lassocoeff={
 	'CLAGE' => (0.01)*$factor,

--- a/test/unit/tool/sir.t
+++ b/test/unit/tool/sir.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
-#use Test::More;
+use Test::Deep;
 use Test::Exception;
 use FindBin qw($Bin);
 use lib "$Bin/../.."; #location of includes.pm
@@ -208,11 +208,12 @@ my $covar = [[3,0.1,0.2],[0.1,8,0.3],[0.2,0.3,2]];
 my $err=linear_algebra::cholesky_transpose($covar);
 
 my $matlabref =[
-[1.732050807568877e+00,                         0,                         0],
-[     5.773502691896259e-02,     2.827837807701613e+00,                         0],
-[     1.154700538379252e-01,     1.037306073687962e-01,     1.405669458927513e+00]
-	];
-is_deeply($covar,$matlabref,'cholesky T');
+    [fnum(1.732050807568877e+00), 0, 0],
+    [fnum(5.773502691896259e-02), fnum(2.827837807701613e+00), 0],
+    [fnum(1.154700538379252e-01), fnum(1.037306073687962e-01),
+        fnum(1.405669458927513e+00)]
+];
+cmp_deeply($covar,$matlabref,'cholesky T');
 
 
 my $root_determinant = $covar->[0][0];
@@ -224,16 +225,19 @@ my $diff = [1,2,3];
 $err = linear_algebra::upper_triangular_transpose_solve($covar,$diff);
 
 
-is_deeply($diff,[5.773502691896258e-01,6.954665721317015e-01,2.035465838166839e+00],' solve R ');
+cmp_deeply($diff,[
+    fnum(5.773502691896258e-01),
+    fnum(6.954665721317015e-01),
+    fnum(2.035465838166839e+00)],' solve R ');
 
 my $sum = 0;
 for (my $i=0; $i< scalar(@{$diff}); $i++){
 	$sum = $sum + ($diff->[$i])**2;
 }
-cmp_float($sum,4.960128264630185,'vecotr prod ');
+cmp_deeply($sum,fnum(4.960128264630185),'vecotr prod ');
 my $pdf = ((2*pi)**(-3/2))*(1/$root_determinant)*exp(-0.5*$sum);
 
-cmp_float($pdf,7.722424963030007e-04,' chol pdf ');
+cmp_deeply($pdf,fnum(7.722424963030007e-04),' chol pdf ');
 
 $covar = [[3,0.1,0.2],[0.1,8,0.3],[0.2,0.3,2]];
 $mu = [1,2,3];

--- a/test/unit/tool/vpc.t
+++ b/test/unit/tool/vpc.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Deep;
 #use Test::More;
 use Test::Exception;
 use FindBin qw($Bin);
@@ -207,8 +208,9 @@ my $realposanswer3 = [[1,-99],[0,-99],[0,-99]]; #censored
 
 #sumwarnigns
 # non_zeros=20
-my $resvalanswer = [[2,66.6666666666667,' ',0,100,1,33.3333333333333,' ',0,100],
-					[2,66.6666666666667,' ',0,100,0,0,' ',0,100],
+my $resvalanswer = [[2,fnum(66.6666666666667),' ',0,100,1,
+                        fnum(33.3333333333333),' ',0,100],
+					[2,fnum(66.6666666666667),' ',0,100,0,0,' ',0,100],
 					[0,0,' ',0,100,0,0,' ',0,100]];
 
 my $resvalanswer2 = [[3,100,' ',0,100,0,0,' ',0,100],
@@ -231,7 +233,7 @@ my ($result_values,$realpos,$stats_warnings);
 
 is($alert,1,'subset_npc_analyze alert');
 is_deeply($realpos,$realposanswer,'subset_npc_analyze real positions');
-is_deeply($result_values,$resvalanswer,'subset_npc_analyze resultvalues');
+cmp_deeply($result_values,$resvalanswer,'subset_npc_analyze resultvalues');
 is_deeply($stats_warnings,$statswarnanswer,'subset_npc_analyze statswarn');
 
 ($result_values,$realpos,$stats_warnings,$alert) = tool::npc::subset_npc_analyze(strata_index => 0,


### PR DESCRIPTION
precisions with the lower-precision expected values in the test suite.

cmp_deeply, together with the utility function "fnum" are used to compare higher-precision actual results with lower-precision expected results.  This more generalized approach  replaces previous ad-hoc approaches such as comp_float_array and cmp_float_matrix.