### PR TITLE
Protect spaces in the directory name when using nmqual (relates to #66)

### DIFF
--- a/lib/nonmemrun.pm
+++ b/lib/nonmemrun.pm
@@ -269,7 +269,7 @@ sub _create_nmqual_command
     unless (defined $xml_file){
         croak("xml_file undefined in _create_nmqual_command, this is a bug");
     }
-    $command_string = " $xml_file $interface ce $work_dir psn $options ";
+    $command_string = " $xml_file $interface ce \"$work_dir\" psn $options ";
 
     $command_string = "perl ".$self->full_path_runscript." $command_string";
     #print "\n$command_string\n";


### PR DESCRIPTION
This implements the change suggested for #66.  I believe that it fixes the PsN side of the issue, but there still appears to be an issue on the `nmqual` side, if my issue tracing is correct.