### PR TITLE
Allow to set PYTHON_PATH via environment variable PSN_PYTHON_PATH.

### DIFF
--- a/lib/PsN.pm
+++ b/lib/PsN.pm
@@ -199,7 +199,9 @@ sub get_python_lib_path
     import();
 
     my $path;
-    if (defined $config->{'_'}->{'PYTHON_PATH'}) {
+    if (defined $ENV{'PSN_PYTHON_PATH'}) {
+        $path = $ENV{'PSN_PYTHON_PATH'};
+    } elsif (defined $config->{'_'}->{'PYTHON_PATH'}) {
         $path = $config->{'_'}->{'PYTHON_PATH'};
     } else {
         $path = '';


### PR DESCRIPTION
This will allow to override the psn.conf option PYTHON_PATH with the environmental variable PSN_PYTHON_PATH.
Will make it easier to share psn.conf between PsN versions, when the Python virtual environment might be different.