### PR TITLE
Replace File::Copy::cp with File::Copy::copy

### DIFF
--- a/bin/boot_scm
+++ b/bin/boot_scm
@@ -13,7 +13,7 @@ use Cwd;
 use common_options;
 use ui;
 use OSspecific;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 # More PsN dependencies included with require further down
 
 my $cmd_line = $0 . " " . join( " ", @ARGV );
@@ -320,7 +320,7 @@ my $main_directory = tool::get_rundir(create => 1,
 
 #copy config file to rundir
 my ( $dir, $file ) = OSspecific::absolute_path('',$options{'config_file'});
-cp($dir.$file,$main_directory.$file);
+copy($dir.$file,$main_directory.$file);
 
 
 #need a dummy tool object to print options
@@ -639,7 +639,7 @@ if (defined $options{'dummy_covariates'}){
         $pathfinaldata = '../../'.$finalname; #local path from $finaldir
     }else{
         #copy original data to main_directory without path
-        cp($fullname,$finaldir.'/'.$finalname);
+        copy($fullname,$finaldir.'/'.$finalname);
         $pathfinaldata = $finalname;
     }
 }

--- a/bin/extended_grid
+++ b/bin/extended_grid
@@ -16,7 +16,7 @@ use File::Basename;
 use PsN;
 use common_options;
 use ui;
-use File::Copy 'cp';
+use File::Copy 'copy';
 # More PsN dependencies included with require further down
 
 my $cmd_line = $0 . " " . join( " ", @ARGV );
@@ -615,7 +615,7 @@ unless ( -e "ofv_dir" ){
   mkdir( "ofv_dir" );
 }
 chdir( "ofv_dir" );
-cp( '../iofvcont.f', './iofvcont.f' ) or print "Warning: unable to copy iofvcont.f\n";
+copy( '../iofvcont.f', './iofvcont.f' ) or print "Warning: unable to copy iofvcont.f\n";
 
 my $table = data->new(
     filename => "extended.nptab",

--- a/bin/linearize
+++ b/bin/linearize
@@ -14,7 +14,7 @@ use common_options;
 use ui;
 use OSspecific;
 use File::Path 'rmtree';
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use include_modules;
 # More PsN dependencies included with require further down
 

--- a/bin/npfit
+++ b/bin/npfit
@@ -17,7 +17,7 @@ use PsN;
 use common_options;
 use ui;
 use Cwd;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use File::Glob;
 use File::Path 'rmtree';
 # More PsN dependencies included with require further down

--- a/bin/parallel_retries
+++ b/bin/parallel_retries
@@ -17,7 +17,7 @@ use PsN;
 use common_options;
 use ui;
 use Cwd;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use File::Glob;
 use File::Path 'rmtree';
 # More PsN dependencies included with require further down
@@ -452,12 +452,12 @@ for (my $i=0; $i< scalar(@{$mod_array->[$selected-1]->output_files}); $i++){
         $to = $models_array->[0]->directory.$filestem.'.'.$models_array->[0]->output_files->[$i];
     }
     if (-e $from){
-        cp($from,$to);
+        copy($from,$to);
         push @copied, basename($to);
         ui -> print( category => 'parallel_retries',
                      message => "copying $from to $to\n" );
     }elsif(-e $tabfrom){
-        cp($tabfrom,$to);
+        copy($tabfrom,$to);
         push @copied, basename($to);
         ui -> print( category => 'parallel_retries',
                      message => "copying $tabfrom to $to\n" );

--- a/bin/psn_clean
+++ b/bin/psn_clean
@@ -9,7 +9,7 @@ use lib "$Bin/../lib";
 
 use PsN;
 use Getopt::Long;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use File::Path 'rmtree';
 use File::Glob;
 use strict;

--- a/bin/rawresults
+++ b/bin/rawresults
@@ -17,7 +17,7 @@ use common_options;
 use ui;
 use Cwd;
 use File::Glob;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use File::Path 'rmtree';
 # More PsN dependencies included with require further down
 

--- a/bin/setup.pl
+++ b/bin/setup.pl
@@ -1,7 +1,7 @@
 use strict;
 use Config;
 use File::Spec;
-use File::Copy qw(cp);
+use File::Copy qw(copy);
 use File::Path qw(mkpath);
 use File::Glob;
 use lib 'lib';
@@ -1054,7 +1054,7 @@ if ($configuration_done) {
     print "\nInstallation complete.\n";
 } else {
     my $path = "$library_dir" . "$directory_separator" . "PsN_$name_safe_version";
-    cp($path . '/psn.conf_template', $path . '/psn.conf');
+    copy($path . '/psn.conf_template', $path . '/psn.conf');
     print "\nInstallation partially complete. You still have to add NONMEM settings to psn.conf before you can run PsN.\n";
     print "A psn.conf to edit is found in\n";
     print "$path\n";

--- a/bin/update_inits
+++ b/bin/update_inits
@@ -9,7 +9,7 @@ use lib "$Bin/../lib";
 
 use PsN;
 use Getopt::Long;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use File::Basename;
 use File::Spec;
 use common_options;
@@ -549,7 +549,7 @@ if ( $options{'output_model'} ){
     $outfile = $options{'output_model'};
 }  else {
     #original file will be overwritten, copy to .org
-    cp( $ARGV[0], $ARGV[0].'.org' );
+    copy( $ARGV[0], $ARGV[0].'.org' );
     unlink($ARGV[0]);
     $outfile = $ARGV[0];
 }

--- a/bin/xv_scm
+++ b/bin/xv_scm
@@ -14,7 +14,7 @@ use Cwd;
 use common_options;
 use ui;
 use OSspecific;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use File::Spec;
 # More PsN dependencies included with require further down
 
@@ -381,7 +381,7 @@ $options{'directory'} = $main_directory;
 
 #copy config file to rundir
 my ( $dir, $file ) = OSspecific::absolute_path('',$options{'config_file'});
-cp($dir . $file, File::Spec->catpath(undef, $main_directory, $file));
+copy($dir . $file, File::Spec->catpath(undef, $main_directory, $file));
 
 $options{'splits'}=1 unless (defined $options{'splits'});
 $options{'groups'}=5 unless (defined $options{'groups'});

--- a/lib/data.pm
+++ b/lib/data.pm
@@ -2,7 +2,7 @@ package data;
 
 use include_modules;
 use OSspecific;
-use File::Copy "cp";
+use File::Copy "copy";
 use Config;
 use random;
 use Storable;

--- a/lib/filter_data.pm
+++ b/lib/filter_data.pm
@@ -4,7 +4,7 @@ package filter_data;
 
 use strict;
 use warnings;
-use File::Copy qw(cp);
+use File::Copy qw(copy);
 use MouseX::Params::Validate;
 use data;
 use model;

--- a/lib/model.pm
+++ b/lib/model.pm
@@ -2,7 +2,7 @@ package model;
 
 use include_modules;
 use Cwd;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use File::Basename;
 use File::Spec qw(splitpath catfile);
 use Config;
@@ -387,7 +387,7 @@ sub create_maxeval_zero_models_array
     my @problem_lines = ();
     while ($samples_done < scalar(@{$sampled_params_arr})) {
         #copy the model
-        $run_model = $model ->  copy( filename    => $subdirectory.$purpose.'_'.$run_num.'.mod',
+        $run_model = $model ->  modelcopy( filename    => $subdirectory.$purpose.'_'.$run_num.'.mod',
                                       output_same_directory => 1,
                                       copy_datafile =>0,
                                       copy_output => 0,
@@ -411,7 +411,7 @@ sub create_maxeval_zero_models_array
 
         if (scalar(@problem_lines)<1){
             #first iteration
-            $dummymodel = $run_model ->  copy( filename    => $subdirectory.$dummyname,
+            $dummymodel = $run_model ->  modelcopy( filename    => $subdirectory.$dummyname,
                                                output_same_directory => 1,
                                                copy_output => 0,
                                                write_copy =>0);
@@ -578,7 +578,7 @@ sub add_records
     }
 }
 
-sub copy
+sub modelcopy
 {
     my $self = shift;
     my %parm = validated_hash(\@_,
@@ -668,7 +668,7 @@ sub copy
             my ($datadir,$datafile) = OSspecific::absolute_path(undef,$datafiles->[$i]);
             unless (-e $writedir.$datafile){
                 if (-e $datadir.$datafile){
-                    cp($datadir.$datafile,$writedir.$datafile);
+                    copy($datadir.$datafile,$writedir.$datafile);
                 }else{
                     croak("data file $datadir$datafile does not exist in writing of ".$self->full_name.
                           " to file $filename") unless $new_model->ignore_missing_data;
@@ -683,7 +683,7 @@ sub copy
     if ($copy_etas) {
         my $phi_file = $self->get_or_set_etas_file();
         if (defined $phi_file) {
-            cp($phi_file, $directory);
+            copy($phi_file, $directory);
             $new_model->get_or_set_etas_file(new_file => basename($phi_file));
         }
     }

--- a/lib/model/problem/msfi.pm
+++ b/lib/model/problem/msfi.pm
@@ -5,7 +5,7 @@ use MouseX::Params::Validate;
 use include_modules;
 use OSspecific;
 use File::Spec qw(abs2rel catfile);
-use File::Copy 'cp';
+use File::Copy 'copy';
 
 extends 'model::problem::record';
 
@@ -226,12 +226,12 @@ sub copy_msfi_file
                 if (-e $new and (not $overwrite)){
                     croak("msfi file $new already exists when copying from $old, and not allowed to overwrite in copy_msfi_file");
                 }else{
-                    cp($old,$new);
+                    copy($old,$new);
                     my $old_extra = get_additional_msfo_files(msfname => $old);
                     my $new_extra = get_additional_msfo_files(msfname => $new);
                     for (my $j=0; $j<scalar(@{$old_extra}); $j++){
                         if (-e $old_extra->[$j]){
-                            cp($old_extra->[$j],$new_extra->[$j]);
+                            copy($old_extra->[$j],$new_extra->[$j]);
                         }
                     }
                 }

--- a/lib/nonmemrun.pm
+++ b/lib/nonmemrun.pm
@@ -3,7 +3,7 @@ package nonmemrun;
 use Config;
 use include_modules;
 use Cwd;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use Mouse;
 use MouseX::Params::Validate;
 

--- a/lib/nonmemrun/ud.pm
+++ b/lib/nonmemrun/ud.pm
@@ -104,7 +104,7 @@ sub retrieve
   }
 
   if ($Config{osname} ne 'MSWin32') {
-    cp($tmp_dir . '/psn.LST', $tmp_dir . '/psn.lst');
+    copy($tmp_dir . '/psn.LST', $tmp_dir . '/psn.lst');
     unlink($tmp_dir . '/psn.LST');
   }
 }

--- a/lib/rplots.pm
+++ b/lib/rplots.pm
@@ -3,7 +3,7 @@ package rplots;
 use Config;
 use include_modules;
 use Cwd;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use File::Spec;
 use File::Basename;
 use Mouse;

--- a/lib/scm_util.pm
+++ b/lib/scm_util.pm
@@ -5,7 +5,7 @@ use MouseX::Params::Validate;
 require tool::scm;
 require tool::scm::config_file;
 require model;
-use File::Copy qw(move mv cp);
+use File::Copy qw(move mv copy);
 use warnings;
 require OSspecific;
 
@@ -79,7 +79,7 @@ sub copy_config_file{
     my $directory = $parm{'directory'};
 
     my ( $dir, $file ) = OSspecific::absolute_path('',$options->{'config_file'});
-    cp($dir.$file,$directory.$file);
+    copy($dir.$file,$directory.$file);
 }
 
 sub setup_model{

--- a/lib/scmplus.pm
+++ b/lib/scmplus.pm
@@ -12,7 +12,7 @@ use scmlogfile;
 use scm_util;
 use warnings;
 use Mouse;
-use File::Copy qw(move mv cp);
+use File::Copy qw(move mv copy);
 use OSspecific;
 use File::Copy::Recursive;
 
@@ -283,7 +283,7 @@ sub setup
 	$self->models->[0] -> _write(filename => $self->directory.'/m1/base_model.mod');
 	if (defined $self->models->[0] ->extra_files()){
 		foreach my $file (@{$self->models->[0] ->extra_files()}){
-			cp($file,$self->directory.'/m1/');
+			copy($file,$self->directory.'/m1/');
 		}
 	}
 	

--- a/lib/so/parsers/psn.pm
+++ b/lib/so/parsers/psn.pm
@@ -7,7 +7,7 @@ use warnings;
 use Mouse;
 use MouseX::Params::Validate;
 use include_modules;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use Cwd;
 use OSspecific;
 
@@ -91,24 +91,24 @@ sub _connector_get_files
         ) {
         #generic failure
         #$errorstring = 'run failure';
-        cp($logfile,$errorfile);  #skip copying, change design
+        copy($logfile,$errorfile);  #skip copying, change design
         @files = ($logfile); #treat error messages as lstfile
     }elsif (($tool eq 'execute') and (not -e $lstfile)) {
         #execute failure
         if (-e $directory.'/NM_run1/psn.lst') {
-            cp($directory.'/NM_run1/psn.lst',$lstfile);
+            copy($directory.'/NM_run1/psn.lst',$lstfile);
             @files = ($lstfile);
         }elsif(-e $directory.'/NM_run1/psn-1.lst'){
-            cp($directory.'/NM_run1/psn-1.lst',$lstfile);
+            copy($directory.'/NM_run1/psn-1.lst',$lstfile);
             @files = ($lstfile);
         }elsif(-e $directory.'/NM_run1/nmtran_error.txt'){
-            cp($directory.'/NM_run1/nmtran_error.txt',$errorfile);
+            copy($directory.'/NM_run1/nmtran_error.txt',$errorfile);
             @files = ($errorfile);
         }elsif( (-e $directory.'/NM_run1/FMSG') and ( not -e $directory.'/NM_run1/FREPORT')) {
-            cp($directory.'/NM_run1/FMSG',$errorfile);
+            copy($directory.'/NM_run1/FMSG',$errorfile);
             @files = ($errorfile);
         }else{
-            cp($logfile,$errorfile);
+            copy($logfile,$errorfile);
             @files = ($logfile);
         }
     }else {
@@ -123,14 +123,14 @@ sub _connector_get_files
         if ($tool eq 'bootstrap'){
             @files = ($lstfile);
         }elsif ($tool eq 'vpc'){
-            cp($directory.'/m1/vpc_simulation.1.lst','.');
-            cp($directory.'/m1/vpc_simulation.1.npctab.dta','npctab.dta');
+            copy($directory.'/m1/vpc_simulation.1.lst','.');
+            copy($directory.'/m1/vpc_simulation.1.npctab.dta','npctab.dta');
             @files = ('vpc_simulation.1.lst');
             my @tab = <$directory/vpctab*>;
-            cp($tab[0],'.');
+            copy($tab[0],'.');
         } elsif ($tool eq 'nca') {
-            cp($directory.'/m1/nca_simulation.1.lst', '.');
-            cp($directory.'/nca_simulation.1.npctab.dta', 'npctab.dta');
+            copy($directory.'/m1/nca_simulation.1.lst', '.');
+            copy($directory.'/nca_simulation.1.npctab.dta', 'npctab.dta');
             @files = ('nca_simulation.1.lst');
             open my $fh, '<', 'npctab.dta';
             <$fh>;
@@ -174,7 +174,7 @@ sub _connector_get_files
             } else {
                 _merge_simulated_tables(destination => $curdir);
                 chdir($curdir);
-                cp($directory . '/m1/mc-1.lst', '.');
+                copy($directory . '/m1/mc-1.lst', '.');
                 @files = ( "mc-1.lst" );
             }
         } else {

--- a/lib/tool.pm
+++ b/lib/tool.pm
@@ -3,7 +3,7 @@ package tool;
 use include_modules;
 use strict;
 use Cwd;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use File::Path qw(mkpath rmtree);
 use File::Spec;
 use Scalar::Util qw(blessed);
@@ -1717,9 +1717,9 @@ sub print_options
 
     if (( -e $dir."/command.txt" ) and not ( -e $dir."/original_command.txt" )){
         #first restart
-        cp($dir . "/command.txt",$dir."/original_command.txt");
+        copy($dir . "/command.txt",$dir."/original_command.txt");
         if (-e $option_file ){
-            cp($option_file,$dir."/original_version_and_option_info.txt");
+            copy($option_file,$dir."/original_version_and_option_info.txt");
         }
     }
 
@@ -1806,9 +1806,9 @@ sub print_options
     if ((lc($toolname) eq 'vpc') or (lc($toolname) eq 'npc')){
         unless ( -e $dir."/original_command.txt" ){
             #first run
-            cp($dir . "/command.txt",$dir."/original_command.txt");
+            copy($dir . "/command.txt",$dir."/original_command.txt");
             if (-e $option_file ){
-                cp($option_file,$dir."/original_version_and_option_info.txt");
+                copy($option_file,$dir."/original_version_and_option_info.txt");
             }
         }
     }

--- a/lib/tool/benchmark.pm
+++ b/lib/tool/benchmark.pm
@@ -2,7 +2,7 @@ package tool::benchmark;
 
 use include_modules;
 use strict;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use data;
 use nonmemrun;
 use OSspecific;

--- a/lib/tool/bootstrap.pm
+++ b/lib/tool/bootstrap.pm
@@ -2,7 +2,7 @@ package tool::bootstrap;
 
 use include_modules;
 use strict;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use Statistics::Distributions 'udistr', 'uprob';
 use random;
 use Mouse;

--- a/lib/tool/cdd.pm
+++ b/lib/tool/cdd.pm
@@ -2,7 +2,7 @@ package tool::cdd;
 
 use include_modules;
 use Cwd;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use tool::llp;
 use tool::modelfit;
 use random;

--- a/lib/tool/frem.pm
+++ b/lib/tool/frem.pm
@@ -8,7 +8,7 @@ use linear_algebra;
 
 use ui;
 use logging;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use File::Path 'rmtree';
 use File::Spec;
 use nmtablefile;
@@ -1090,7 +1090,7 @@ sub do_model1
             my $extra_file_copy = utils::file::replace_extension($model1_name, $ext);
             my $extra_file_orig_path = File::Spec->catfile($model_dir, $extra_file_orig);
             if (-f $extra_file_orig_path) {
-                cp($extra_file_orig_path, File::Spec->catfile($self->_intermediate_models_path, $extra_file_copy));
+                copy($extra_file_orig_path, File::Spec->catfile($self->_intermediate_models_path, $extra_file_copy));
             }
         }
 
@@ -1832,7 +1832,7 @@ sub prepare_model3
 
             # copy M2 output to M3 input phi file
             (my $etas_filename = $name_model) =~ s/(.*)\..*/$1_input.phi/;
-            cp($etas_file, File::Spec->catfile($im_dir, $etas_filename));
+            copy($etas_file, File::Spec->catfile($im_dir, $etas_filename));
             (undef, $etas_filename) = OSspecific::absolute_path($im_dir, $etas_filename);
 
             # update FILE in model to new path (just filename since same directory)
@@ -1937,14 +1937,14 @@ sub prepare_model4
                 $option->init(0.000001);
             }
         }
-        cp(File::Spec->catfile($self->_intermediate_models_path, 'model_2.phi'), File::Spec->catfile($self->_final_models_path, 'model_4_input.phi'));
+        copy(File::Spec->catfile($self->_intermediate_models_path, 'model_2.phi'), File::Spec->catfile($self->_final_models_path, 'model_4_input.phi'));
     } elsif ($best_ofv == $mod3_ofv) {
         print "Starting model4 from model3\n";
         $frem_model->update_inits(from_output => $output3);
-        cp(File::Spec->catfile($self->_intermediate_models_path, 'model_3.phi'), File::Spec->catfile($self->_final_models_path, 'model_4_input.phi'));
+        copy(File::Spec->catfile($self->_intermediate_models_path, 'model_3.phi'), File::Spec->catfile($self->_final_models_path, 'model_4_input.phi'));
     } else {
         print "Starting model4 from model3b\n";
-        cp(File::Spec->catfile($self->_intermediate_models_path, 'model_3b.phi'), File::Spec->catfile($self->_final_models_path, 'model_4_input.phi'));
+        copy(File::Spec->catfile($self->_intermediate_models_path, 'model_3b.phi'), File::Spec->catfile($self->_final_models_path, 'model_4_input.phi'));
     }
 
     $frem_model->get_or_set_etas_file(problem_number => 1, new_file => 'model_4_input.phi');

--- a/lib/tool/linearize.pm
+++ b/lib/tool/linearize.pm
@@ -3,7 +3,7 @@ package tool::linearize;
 use Mouse;
 use MouseX::Params::Validate;
 use File::Path;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use tool;
 use tool::modelfit;
 use tool::scm;
@@ -97,16 +97,16 @@ sub modelfit_setup
         unlink($scm->directory . 'base_model.mod');
         my @files = glob($scm->directory . $scm->basename . '*');
         for my $file (@files) {
-            cp($file, '.');
+            copy($file, '.');
         }
 
-        cp($scm->basename . '.dta', '../' . $scm->basename . '.dta');
-        cp($scm->basename . '.mod', '../' . $scm->basename . '.mod');
-        cp($scm->basename . '.lst', '../' . $scm->basename . '.lst');
-        cp($scm->basename . '.phi', '../' . $scm->basename . '.phi');
-        cp($scm->basename . '.ext', '../' . $scm->basename . '.ext');
-        cp($scm->basename . '.cov', '../' . $scm->basename . '.cov');
-        cp($scm->basename . '.coi', '../' . $scm->basename . '.coi');
+        copy($scm->basename . '.dta', '../' . $scm->basename . '.dta');
+        copy($scm->basename . '.mod', '../' . $scm->basename . '.mod');
+        copy($scm->basename . '.lst', '../' . $scm->basename . '.lst');
+        copy($scm->basename . '.phi', '../' . $scm->basename . '.phi');
+        copy($scm->basename . '.ext', '../' . $scm->basename . '.ext');
+        copy($scm->basename . '.cov', '../' . $scm->basename . '.cov');
+        copy($scm->basename . '.coi', '../' . $scm->basename . '.coi');
     } else {
         my $derivatives_model = model_approximations::second_order_derivatives_model(model => $model);
         if ($model->is_run()) {

--- a/lib/tool/llp.pm
+++ b/lib/tool/llp.pm
@@ -1,7 +1,7 @@
 package tool::llp;
 
 use include_modules;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use Math::SigFigs;
 use tool::modelfit;
 use Mouse;

--- a/lib/tool/mcmp.pm
+++ b/lib/tool/mcmp.pm
@@ -7,7 +7,7 @@ use tool::modelfit;
 use model;
 use ui;
 use Config;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use POSIX;
 use OSspecific;
 use Mouse;
@@ -496,7 +496,7 @@ sub modelfit_setup
                 my $dirt;
                 ($dirt, $simulated_file) =
                     OSspecific::absolute_path('', $self -> simdata() );
-                cp($self -> simdata(),$self -> directory.'m1/'.$simulated_file);
+                copy($self -> simdata(),$self -> directory.'m1/'.$simulated_file);
             }
             $sim_file= $self -> directory.'m1/'.$simulated_file;
             my @new_names = ($sim_file) x scalar(@{$mod ->problems});

--- a/lib/tool/modelfit.pm
+++ b/lib/tool/modelfit.pm
@@ -4,7 +4,7 @@ use include_modules;
 use Config;
 use Cwd;
 use Data::Dumper;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use File::Path;
 use File::Glob;
 use File::Spec;
@@ -1049,7 +1049,7 @@ sub select_best_model
                 } else {
                     $outfilename = $self->base_directory . $self->model_subdir_name . $model->outputs->[0]->filename;
                 }
-                cp("psn.lst", $outfilename);
+                copy("psn.lst", $outfilename);
             }
         } else {
             my @raw_results_rows = @{$queue_info_ref -> {'raw_results'} -> [$selected-1]};
@@ -2467,7 +2467,7 @@ sub restart_needed
             my $new_name = get_retry_name( filename => 'psn.'.$self->modext,
                                            retry => ${$tries},
                                            crash => $queue_info_ref -> {'crashes'});
-            cp( $new_name, 'psn.'.$self->modext );
+            copy( $new_name, 'psn.'.$self->modext );
         }
 
         $output_file -> flush;
@@ -2853,7 +2853,7 @@ sub copy_model_and_input
                 # $file is a ref to an array with two elements, the first is a
                 # path, the second is a name.
 
-                cp( $file->[0] . $file -> [1], $file -> [1] ); #FIXME symlink if on linux?
+                copy( $file->[0] . $file -> [1], $file -> [1] ); #FIXME symlink if on linux?
 
             }
 
@@ -2910,7 +2910,7 @@ sub copy_model_and_input
             # $file is a ref to an array with two elements, the first is a
             # path, the second is a name.
 
-            cp( $file->[0] . $file -> [1], $file -> [1] ); #FIXME symlink if unix?
+            copy( $file->[0] . $file -> [1], $file -> [1] ); #FIXME symlink if unix?
 
         }
 
@@ -2952,7 +2952,7 @@ sub copy_model_and_input
             if( defined $msfi_in and (-s $msfi_in) ){
                 #-s returns true if file is non-empty
                 #assume original model has msfi, assume thetas already removed.
-                cp( $msfi_in, $basename.'-0' ); #move or copy... this is from calling directory
+                copy( $msfi_in, $basename.'-0' ); #move or copy... this is from calling directory
                 #assume only one $MSFI per $PROB.
                 if (defined $candidate_model->problems->[0]->msfis){
                     $candidate_model->problems->[0]->msfis->[0]->set_filename(filename =>$basename.'-0');
@@ -3140,7 +3140,7 @@ sub move_model_and_output
         # Don't prepend the model file name to psn.lst, but use the name
         # from the $model object.
         if ($filename eq 'psn.lst') {
-            my $success = cp($filename, $outfilename);
+            my $success = copy($filename, $outfilename);
             $final_lst = $outfilename;
             (undef, undef, my $lst_name) = File::Spec->splitpath($outfilename);
             if ($success) {
@@ -3157,9 +3157,9 @@ sub move_model_and_output
                     if ('.'.$out eq $ext){
                         my $success;
                         if ($self->model_subdir) {
-                            $success = cp($filename, $self->base_directory . $self->model_subdir_name . $dotless_model_filename . $ext);
+                            $success = copy($filename, $self->base_directory . $self->model_subdir_name . $dotless_model_filename . $ext);
                         } else {
-                            $success = cp($filename, $dir . $dotless_model_filename . $ext);
+                            $success = copy($filename, $dir . $dotless_model_filename . $ext);
                         }
                         if ($success) {
                             push @{$self->metadata->{'copied_files'}}, $dotless_model_filename . $ext;
@@ -3182,7 +3182,7 @@ sub move_model_and_output
             $destination .= "$dotless_model_filename.";
         }
         $destination .= $filename;
-        cp($filename, $destination);
+        copy($filename, $destination);
         push @{$self->metadata->{'copied_files'}}, $filename;
     }
 
@@ -3270,7 +3270,7 @@ sub move_model_and_output
             my $so = so->new();
             my $nm_parser = so::parsers::nmoutput->new(so => $so, lst_file => $final_lst);
             $so->write();
-            cp($so->filename, $model->directory);
+            copy($so->filename, $model->directory);
             unlink($so->filename);
         }
     }

--- a/lib/tool/nonparametric.pm
+++ b/lib/tool/nonparametric.pm
@@ -3,7 +3,7 @@ package tool::nonparametric;
 use strict;
 use Mouse;
 use MouseX::Params::Validate;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use include_modules;
 use data;
 use filter_data;

--- a/lib/tool/npc.pm
+++ b/lib/tool/npc.pm
@@ -8,7 +8,7 @@ use model;
 use ui;
 use Config;
 use OSspecific;
-use File::Copy qw/cp mv/;
+use File::Copy qw/copy mv/;
 use File::Spec;
 use Cwd;
 use binning;
@@ -2753,7 +2753,7 @@ sub get_tte_data
             ui -> print (category=>'vpc', message=>"\nRenamed original mytab$tabno, new name ".
                          "mytab$tabno"."_original. New mytab$tabno can be used for kaplan.plot in Xpose.");
         }
-        cp('mytab'.$tabno, $self->models->[0]->directory().'mytab'.$tabno);
+        copy('mytab'.$tabno, $self->models->[0]->directory().'mytab'.$tabno);
     }else{
         mv ($orig_file,'mytab1');
     }

--- a/lib/tool/proseval.pm
+++ b/lib/tool/proseval.pm
@@ -3,7 +3,7 @@ package tool::proseval;
 use strict;
 use Mouse;
 use MouseX::Params::Validate;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use include_modules;
 use data;
 use filter_data;

--- a/lib/tool/qa.pm
+++ b/lib/tool/qa.pm
@@ -4,7 +4,7 @@ use strict;
 use random;
 use Mouse;
 use MouseX::Params::Validate;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use File::Spec;
 use include_modules;
 use array;
@@ -549,12 +549,12 @@ sub modelfit_setup
             my $scm_model = $base_model->copy(directory => "m1", filename => "scm.mod", write_copy => 0);
             if ($base_model->is_run()) {
                 my $lst_path = $base_model->outputs->[0]->full_name();
-                cp($lst_path, 'm1/scm.lst');
+                copy($lst_path, 'm1/scm.lst');
                 my $ext_path = utils::file::replace_extension($lst_path, 'ext');
-                cp($ext_path, 'm1/scm.ext');
+                copy($ext_path, 'm1/scm.ext');
                 my $phi_file = $base_model->get_phi_file;
                 if (defined $phi_file and -e $phi_file) {
-                    cp($phi_file, 'm1/scm.phi');
+                    copy($phi_file, 'm1/scm.phi');
                 }
             }
             $scm_model->set_records(type => 'covariance', record_strings => [ "OMITTED" ]);

--- a/lib/tool/randtest.pm
+++ b/lib/tool/randtest.pm
@@ -2,7 +2,7 @@ package tool::randtest;
 
 use include_modules;
 use strict;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use data;
 use OSspecific;
 use tool::modelfit;

--- a/lib/tool/scm.pm
+++ b/lib/tool/scm.pm
@@ -6,7 +6,7 @@ use Cwd;
 use tool::modelfit;
 use OSspecific;
 use Data::Dumper;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use File::Spec;
 use List::Util qw(max);
 use status_bar;
@@ -2677,9 +2677,9 @@ sub linearize_setup
                 #copy deepest derivatives_covariates.dta from forward_scm_dir and put it locally with correct name
                 # $datafilename
                 if (-e $dir.'derivatives_covariates'.$stepname.'.dta' ){
-                    cp( $dir.'derivatives_covariates'.$stepname.'.dta', "$datafilename" );
-                    cp( $old_derivatives.'mod', 'copy_last_forward_derivatives.mod');
-                    cp( $old_derivatives.'lst', 'copy_last_forward_derivatives.lst');
+                    copy( $dir.'derivatives_covariates'.$stepname.'.dta', "$datafilename" );
+                    copy( $old_derivatives.'mod', 'copy_last_forward_derivatives.mod');
+                    copy( $old_derivatives.'lst', 'copy_last_forward_derivatives.lst');
                 }else{
                     ui -> print( category => 'scm',
                         message  => "cannot find old derivatives data, rerunning",
@@ -2756,7 +2756,7 @@ sub linearize_setup
 
         if ($self->step_number()==1 and $self->derivatives_data()){
             #do not run derivatives model, instead copy file to right name
-            cp( $self->derivatives_data(), $datafilename );
+            copy( $self->derivatives_data(), $datafilename );
         } elsif ($rerun_derivatives_new_direction){
             #run derivatives_model
             my $derivatives_fit = tool::modelfit -> new
@@ -3922,7 +3922,7 @@ sub _create_models
             my $filename = $orig_model->datafiles(absolute_path => 0)->[0];
             my $string = File::Spec->catfile($self -> directory,$filename);
             if ($fullpath ne $string) { # For the same path do not copy to avoid warning
-                cp($fullpath, $string);
+                copy($fullpath, $string);
             }
             $self->main_data_file($string);
         }else{
@@ -4935,7 +4935,7 @@ sub run_xv_pred_step
         my $datafilename = 'derivatives_covariates.dta';
         my $newfilename = 'derivatives_covariates_pred.dta';
 
-        cp($datafilename,$newfilename);
+        copy($datafilename,$newfilename);
         unlink($datafilename);
         my ( $dir, $file ) = OSspecific::absolute_path('',$newfilename);
 
@@ -5584,8 +5584,8 @@ sub write_final_models
     $final_model->directory( $fdir);
     $fname =~ s/\.mod/\.lst/;
     return unless (-e $final_model->outputfile); #unless lst-file exists (could have crashed)
-    cp($final_model->outputfile, "$fdir$fname");
-    cp(utils::file::replace_extension($final_model->outputfile, 'ext'), utils::file::replace_extension("$fdir$fname", "ext"));     # Also copy the ext file to get better precision on inits
+    copy($final_model->outputfile, "$fdir$fname");
+    copy(utils::file::replace_extension($final_model->outputfile, 'ext'), utils::file::replace_extension("$fdir$fname", "ext"));     # Also copy the ext file to get better precision on inits
     my $prob_num = undef;
     $final_model->update_inits(
         from_output => $final_model->outputs->[0],

--- a/lib/tool/sir.pm
+++ b/lib/tool/sir.pm
@@ -2,7 +2,7 @@ package tool::sir;
 
 use include_modules;
 use strict;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use data;
 use OSspecific;
 use tool::modelfit;
@@ -1189,7 +1189,7 @@ sub load_restart_information
             #and change last item in intermediate_raw_results_files
             #in order to get this as intermediate rawres in add_iterations run
             my $newname = 'raw_results_sir_iteration'.$iteration.'.csv';
-            cp($self->directory.$intermediate_raw_results_files[-1],$self->directory.$newname);
+            copy($self->directory.$intermediate_raw_results_files[-1],$self->directory.$newname);
             $intermediate_raw_results_files[-1] = $newname;
         }
         $self->intermediate_raw_results_files(\@intermediate_raw_results_files);

--- a/test/includes.pm
+++ b/test/includes.pm
@@ -5,7 +5,7 @@ use File::Spec;
 use Cwd;
 use Test::More;
 use File::Path 'rmtree';
-use File::Copy 'cp';
+use File::Copy 'copy';
 use Config;
 
 require Exporter;
@@ -314,7 +314,7 @@ sub copy_test_files
 	my $testdir = shift;
 	my $array = shift;
 	foreach $file (@{$array}) {
-		cp("$testfiledir/$file", $testdir) or die "copy_test_files failed: $!";
+		copy("$testfiledir/$file", $testdir) or die "copy_test_files failed: $!";
 	}
 }
 
@@ -357,7 +357,7 @@ sub do_course_tests
 	my $model_dir = "$dir/$course_name";
 	my @needed = <$model_dir/*>;
 	foreach my $file (@needed) {
-		cp($file, $tempdir . '/.');
+		copy($file, $tempdir . '/.');
 	}
 	chdir($tempdir);
 

--- a/test/system/benchmark.t
+++ b/test/system/benchmark.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/boot_scm.t
+++ b/test/system/boot_scm.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/data_parsing.t
+++ b/test/system/data_parsing.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/execute.t
+++ b/test/system/execute.t
@@ -14,7 +14,7 @@ use Config;
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition
-use File::Copy 'cp';
+use File::Copy 'copy';
 
 
 our $tempdir = create_test_dir('system_execute');
@@ -34,8 +34,8 @@ SKIP: {
 
     my $spacedir = 'a b';
     mkdir($spacedir);
-    cp('pheno.mod',$spacedir);
-    cp('pheno.dta',$spacedir);
+    copy('pheno.mod',$spacedir);
+    copy('pheno.dta',$spacedir);
     chdir($spacedir);
     my $command = get_command('execute') . " pheno.mod -no-copy_data";
     print "Running $command\n";

--- a/test/system/linearize.t
+++ b/test/system/linearize.t
@@ -5,7 +5,7 @@ use warnings;
 use File::Path qw(make_path);
 use File::Spec;
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/llp.t
+++ b/test/system/llp.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More tests=>1;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/mcmp.t
+++ b/test/system/mcmp.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/mimp.t
+++ b/test/system/mimp.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More tests=>1;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/modelfit.t
+++ b/test/system/modelfit.t
@@ -14,7 +14,7 @@ use Config;
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition
-use File::Copy 'cp';
+use File::Copy 'copy';
 use tool::modelfit;
 use common_options;
 sub check_diff

--- a/test/system/nmoutput2so.t
+++ b/test/system/nmoutput2so.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/npc.t
+++ b/test/system/npc.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More tests=>2;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/npfit.t
+++ b/test/system/npfit.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/parallel_retries.t
+++ b/test/system/parallel_retries.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More tests=>1;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/pind.t
+++ b/test/system/pind.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More tests=>1;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/randtest.t
+++ b/test/system/randtest.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/rawres_input.t
+++ b/test/system/rawres_input.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/record_order.t
+++ b/test/system/record_order.t
@@ -10,7 +10,7 @@ use Config;
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition
-use File::Copy 'cp';
+use File::Copy 'copy';
 use ui;
 
 our $tempdir = create_test_dir('system_record_order');

--- a/test/system/resmod.t
+++ b/test/system/resmod.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition
@@ -16,8 +16,8 @@ SKIP: {
     our $tempdir = create_test_dir('system_resmod');
     chdir($tempdir);
     my $model_dir = $includes::testfiledir;
-    cp("$model_dir/resmod/sdtab", $tempdir);
-    cp("$model_dir/resmod/pheno.mod", $tempdir);
+    copy("$model_dir/resmod/sdtab", $tempdir);
+    copy("$model_dir/resmod/pheno.mod", $tempdir);
 
 
     my @commands = ( 

--- a/test/system/simeval.t
+++ b/test/system/simeval.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/sir.t
+++ b/test/system/sir.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/sse.t
+++ b/test/system/sse.t
@@ -10,7 +10,7 @@ use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition
 
-use File::Copy 'cp';
+use File::Copy 'copy';
 
 #in psn.conf must set output_style = SPLUS, otherwise tests will fail. fix by setting here.
 
@@ -24,7 +24,7 @@ my $tndir = "$tempdir/tndir";
 mkdir($tndir);
 my $mod = 'tnpri.mod';
 foreach my $file ("$model_dir/tnpri.mod","$model_dir/data_tnpri.csv","$model_dir/create_tnpri_msf.mod"){
-	cp($file, "$tndir/.");
+	copy($file, "$tndir/.");
 }
 chdir($tndir);
 

--- a/test/system/vpc.t
+++ b/test/system/vpc.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/system/xv_scm.t
+++ b/test/system/xv_scm.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More tests=>1;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition
@@ -21,7 +21,7 @@ my $bootdir = "$tempdir/boot_xv_scm_test";
 
 mkdir($bootdir);
 foreach my $file (@needed){
-	cp($file,"$bootdir/.");
+	copy($file,"$bootdir/.");
 }
 chdir($bootdir);
 my @scmcommands = 

--- a/test/unit/bin/sumo.t
+++ b/test/unit/bin/sumo.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/../.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/unit/data_bootstrap.t
+++ b/test/unit/data_bootstrap.t
@@ -14,12 +14,12 @@ use data;
 use model::problem::data;
 use model::problem;
 use model;
-use File::Copy 'cp';
+use File::Copy 'copy';
 
 #test for data class subroutine for bootstrap
 my $tempdir = create_test_dir('unit_data_bootstrap');
 
-cp($includes::testfiledir.'/pheno.dta',$tempdir);
+copy($includes::testfiledir.'/pheno.dta',$tempdir);
 my ( $new_datas, $incl_ids, $incl_keys, $new_subjects, $orig_count_ind )
 	= data::bootstrap_create_datasets( output_directory   => $tempdir,
 									   name_stub   => 'bs_pr1',
@@ -50,7 +50,7 @@ $data = data->new(
 is($data->count_ind,59,'count boot data 1');
 
 
-cp($includes::testfiledir.'/data/with_dates_and_times.csv',$tempdir);
+copy($includes::testfiledir.'/data/with_dates_and_times.csv',$tempdir);
 ($new_datas, $incl_ids, $incl_keys, $new_subjects, $orig_count_ind )
 	= data::bootstrap_create_datasets( output_directory   => $tempdir,
 	name_stub   => 'bsa_',

--- a/test/unit/data_cdd.t
+++ b/test/unit/data_cdd.t
@@ -14,12 +14,12 @@ use data;
 use model::problem::data;
 use model::problem;
 use model;
-use File::Copy 'cp';
+use File::Copy 'copy';
 
 #test for data class subroutine for cdd 
 my $tempdir = create_test_dir('unit_data_cdd');
 
-cp($includes::testfiledir.'/pheno5.dta',$tempdir);
+copy($includes::testfiledir.'/pheno5.dta',$tempdir);
 my ($new_datas, $skip_ids, $skip_keys, $skip_values, $remainders, $pr_bins) = 
 	data::cdd_create_datasets(input_filename => $tempdir.'pheno5.dta',
 							  bins => undef,

--- a/test/unit/data_extra.t
+++ b/test/unit/data_extra.t
@@ -14,7 +14,7 @@ use data;
 use model::problem::data;
 use model::problem;
 use model;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use Cwd;
 use Config;
 use OSspecific;
@@ -26,8 +26,8 @@ use File::Spec qw(catfile);
 ui->silent(1);
 my $tempdir = create_test_dir('unit_data_extra');
 
-cp($includes::testfiledir.'/frem_filtered_data.dta',$tempdir);
-cp($includes::testfiledir.'/frem_filtered_nomdv.dta',$tempdir);
+copy($includes::testfiledir.'/frem_filtered_data.dta',$tempdir);
+copy($includes::testfiledir.'/frem_filtered_nomdv.dta',$tempdir);
 
 
 my $filtered_data_nomdv = data->new(filename => $tempdir.'frem_filtered_nomdv.dta',

--- a/test/unit/helptexts.t
+++ b/test/unit/helptexts.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use File::Path 'rmtree';
 use Test::More;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use FindBin qw($Bin);
 use lib "$Bin/.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition

--- a/test/unit/msfi.t
+++ b/test/unit/msfi.t
@@ -14,7 +14,7 @@ use data;
 use model::problem::msfi;
 use model::problem;
 use model;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use Cwd;
 use OSspecific;
 use File::Spec qw(catfile);

--- a/test/unit/tool/bootstrap.t
+++ b/test/unit/tool/bootstrap.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Exception;
-use File::Copy qw(cp);
+use File::Copy qw(copy);
 use FindBin qw($Bin);
 use lib "$Bin/../.."; #location of includes.pm
 use includes; #file with paths to PsN packages
@@ -70,8 +70,8 @@ $model = model->new(
 );
 
 my $bootstrap = tool::bootstrap->new(directory => $tempdir, skip_estimate_near_boundary => 1, models => [ $model ]);
-cp("$test_files/bootstrap/raw_results_pheno.csv", "$tempdir/raw_results.csv");
-cp("$test_files/bootstrap/raw_results_structure", $tempdir);
+copy("$test_files/bootstrap/raw_results_pheno.csv", "$tempdir/raw_results.csv");
+copy("$test_files/bootstrap/raw_results_structure", $tempdir);
 
 $bootstrap->prepare_results();
 
@@ -452,8 +452,8 @@ remove_test_dir($tempdir);
 $tempdir = create_test_dir("unit_bootstrap");
 
 $bootstrap = tool::bootstrap->new(directory => $tempdir, skip_estimate_near_boundary => 1, models => [ $model ]);
-cp("$test_files/bootstrap/missing_original_model/raw_results_pheno.csv", "$tempdir/raw_results.csv");
-cp("$test_files/bootstrap/missing_original_model/raw_results_structure", $tempdir);
+copy("$test_files/bootstrap/missing_original_model/raw_results_pheno.csv", "$tempdir/raw_results.csv");
+copy("$test_files/bootstrap/missing_original_model/raw_results_structure", $tempdir);
 
 $bootstrap->prepare_results();
 
@@ -487,8 +487,8 @@ remove_test_dir($tempdir);
 $tempdir = create_test_dir("unit_bootstrap");
 
 $bootstrap = tool::bootstrap->new(directory => $tempdir, skip_estimate_near_boundary => 1, models => [ $model ]);
-cp("$test_files/bootstrap/skipped_original_model/raw_results_pheno.csv", "$tempdir/raw_results.csv");
-cp("$test_files/bootstrap/skipped_original_model/raw_results_structure", $tempdir);
+copy("$test_files/bootstrap/skipped_original_model/raw_results_pheno.csv", "$tempdir/raw_results.csv");
+copy("$test_files/bootstrap/skipped_original_model/raw_results_structure", $tempdir);
 
 $bootstrap->prepare_results();
 
@@ -544,8 +544,8 @@ remove_test_dir($tempdir);
 $tempdir = create_test_dir("unit_bootstrap");
 
 $bootstrap = tool::bootstrap->new(directory => $tempdir, skip_minimization_terminated => 0, models => [ $model ]);
-cp("$test_files/bootstrap/somecrash/raw_results_pheno.csv", "$tempdir/raw_results.csv");
-cp("$test_files/bootstrap/somecrash/raw_results_structure", $tempdir);
+copy("$test_files/bootstrap/somecrash/raw_results_pheno.csv", "$tempdir/raw_results.csv");
+copy("$test_files/bootstrap/somecrash/raw_results_structure", $tempdir);
 
 $bootstrap->prepare_results();
 
@@ -570,8 +570,8 @@ $bootstrap = tool::bootstrap->new(directory => $tempdir,
 	skip_with_covstep_warnings => 0,
 	skip_estimate_near_boundary => 1,
 	models => [ $model ]);
-cp("$test_files/bootstrap/with_dofv/raw_results_mox_sir_block2.csv", "$tempdir/raw_results.csv");
-cp("$test_files/bootstrap/with_dofv/raw_results_structure", $tempdir);
+copy("$test_files/bootstrap/with_dofv/raw_results_mox_sir_block2.csv", "$tempdir/raw_results.csv");
+copy("$test_files/bootstrap/with_dofv/raw_results_structure", $tempdir);
 
 $bootstrap->prepare_results();
 
@@ -617,8 +617,8 @@ $bootstrap = tool::bootstrap->new(directory => $tempdir,
 	skip_with_covstep_warnings => 0,
 	skip_estimate_near_boundary => 0,
 	models => [ $model ]);
-cp("$test_files/bootstrap/some_covstep_fail/raw_results_mox_sir_block2.csv", "$tempdir/raw_results.csv");
-cp("$test_files/bootstrap/some_covstep_fail/raw_results_structure", $tempdir);
+copy("$test_files/bootstrap/some_covstep_fail/raw_results_mox_sir_block2.csv", "$tempdir/raw_results.csv");
+copy("$test_files/bootstrap/some_covstep_fail/raw_results_structure", $tempdir);
 
 $bootstrap->prepare_results();
 

--- a/test/unit/tool/cdd.t
+++ b/test/unit/tool/cdd.t
@@ -13,7 +13,7 @@ use includes; #file with paths to PsN packages and $path variable definition
 use tool::cdd;
 use output;
 use model;
-use File::Copy 'cp';
+use File::Copy 'copy';
 use File::Spec;
 
 

--- a/test/unit/tool/resmod.t
+++ b/test/unit/tool/resmod.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Exception;
-use File::Copy qw(cp);
+use File::Copy qw(copy);
 use FindBin qw($Bin);
 use lib "$Bin/../.."; #location of includes.pm
 use includes; #file with paths to PsN packages

--- a/test/unit/tool/sir.t
+++ b/test/unit/tool/sir.t
@@ -14,7 +14,7 @@ use random;
 use output;
 use tool::sir;
 use linear_algebra;
-use File::Copy 'cp';
+use File::Copy 'Copy';
 
 
 
@@ -514,8 +514,8 @@ my $recovery_filename = 'restart_information_do_not_edit.pl';
 my $sirdir='sir_dir1';
 mkdir($sirdir);
 chdir($sirdir);
-cp("$modeldir/pheno.mod",'pheno.mod');
-cp("$modeldir/pheno.dta",'pheno.dta');
+copy("$modeldir/pheno.mod",'pheno.mod');
+copy("$modeldir/pheno.dta",'pheno.dta');
 
 my @center_rawresults_vector=(1,2,3,4,5);
 

--- a/test/unit/tool/sse.t
+++ b/test/unit/tool/sse.t
@@ -11,7 +11,7 @@ use FindBin qw($Bin);
 use lib "$Bin/../.."; #location of includes.pm
 use includes; #file with paths to PsN packages and $path variable definition
 
-use File::Copy 'cp';
+use File::Copy 'copy';
 use File::Spec;
 
 #in psn.conf must set output_style = SPLUS, otherwise tests will fail. fix by setting here.

--- a/test/unit/tool/tool.t
+++ b/test/unit/tool/tool.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use File::Path 'rmtree';
-use File::Copy 'cp';
+use File::Copy 'copy';
 use Test::More;
 use Test::Exception;
 use Cwd 'abs_path';
@@ -124,7 +124,7 @@ ok (-e "$dir/command.txt", "compress_m1 command.txt still exists");
 # uncompress_m1
 
 mkdir("$tempdir/bak");
-cp("$dir/m1.zip", "$tempdir/bak");
+copy("$dir/m1.zip", "$tempdir/bak");
 
 # m1.zip exists and is non-empty, m1 does not exist
 $tool->uncompress_m1();
@@ -160,7 +160,7 @@ rmtree([$dir]);
 mkdir($dir);
 mkdir($m1_dir);
 copy_test_files($dir, ["bootstrap/bootstrap_dir1/command.txt"]);
-cp("$tempdir/bak/m1.zip", $dir);
+copy("$tempdir/bak/m1.zip", $dir);
 $tool->uncompress_m1();
 ok (-e $m1_dir, "uncompress_m1 (empty, exists) m1 created");
 ok (-e "$dir/command.txt", "uncompress_m1 (empty, exists) command.txt still exists");
@@ -199,7 +199,7 @@ mkdir($dir);
 mkdir($m1_dir);
 copy_test_files($dir, ["bootstrap/bootstrap_dir1/command.txt"]);
 copy_test_files("$dir/m1", ["bootstrap/bootstrap_dir1/m1/bs_pr1_1.cor"]);
-cp("$tempdir/bak/m1.zip", $dir);
+copy("$tempdir/bak/m1.zip", $dir);
 dies_ok { $tool->uncompress_m1() } "uncompress_m1 (non-empty, non-empty) dies";
 
 #m1=non-existing, m1.zip=empty


### PR DESCRIPTION
File::Copy::copy uses the default permissions for the target file (which may depend on the process' "umask", file ownership, inherited ACLs, etc.), compare to cp which force the permissions to what the source file have.

The sub copy in lib/model.pm was renamed to modelcopy to make the transition from cp to copy possible.